### PR TITLE
Mark braced-groups within expressions with __extension__

### DIFF
--- a/urcu-bp.h
+++ b/urcu-bp.h
@@ -94,6 +94,7 @@ extern int rcu_read_ongoing(void);
 
 extern void *rcu_dereference_sym_bp(void *p);
 #define rcu_dereference_bp(p)						     \
+	__extension__							     \
 	({								     \
 		__typeof__(p) _________p1 = URCU_FORCE_CAST(__typeof__(p),   \
 			rcu_dereference_sym_bp(URCU_FORCE_CAST(void *, p))); \
@@ -102,6 +103,7 @@ extern void *rcu_dereference_sym_bp(void *p);
 
 extern void *rcu_cmpxchg_pointer_sym_bp(void **p, void *old, void *_new);
 #define rcu_cmpxchg_pointer_bp(p, old, _new)				     \
+	__extension__							     \
 	({								     \
 		__typeof__(*(p)) _________pold = (old);			     \
 		__typeof__(*(p)) _________pnew = (_new);		     \
@@ -114,6 +116,7 @@ extern void *rcu_cmpxchg_pointer_sym_bp(void **p, void *old, void *_new);
 
 extern void *rcu_xchg_pointer_sym_bp(void **p, void *v);
 #define rcu_xchg_pointer_bp(p, v)					     \
+	__extension__							     \
 	({								     \
 		__typeof__(*(p)) _________pv = (v);			     \
 		__typeof__(*(p)) _________p1 = URCU_FORCE_CAST(__typeof__(*(p)),\
@@ -124,6 +127,7 @@ extern void *rcu_xchg_pointer_sym_bp(void **p, void *v);
 
 extern void *rcu_set_pointer_sym_bp(void **p, void *v);
 #define rcu_set_pointer_bp(p, v)					     \
+	__extension__							     \
 	({								     \
 		__typeof__(*(p)) _________pv = (v);			     \
 		__typeof__(*(p)) _________p1 = URCU_FORCE_CAST(__typeof__(*(p)), \

--- a/urcu-pointer.h
+++ b/urcu-pointer.h
@@ -66,6 +66,7 @@ extern "C" {
 
 extern void *rcu_dereference_sym(void *p);
 #define rcu_dereference(p)						     \
+	__extension__							     \
 	({								     \
 		__typeof__(p) _________p1 =	URCU_FORCE_CAST(__typeof__(p), \
 			rcu_dereference_sym(URCU_FORCE_CAST(void *, p)));    \
@@ -74,6 +75,7 @@ extern void *rcu_dereference_sym(void *p);
 
 extern void *rcu_cmpxchg_pointer_sym(void **p, void *old, void *_new);
 #define rcu_cmpxchg_pointer(p, old, _new)				     \
+	__extension__							     \
 	({								     \
 		__typeof__(*(p)) _________pold = (old);			     \
 		__typeof__(*(p)) _________pnew = (_new);		     \
@@ -86,6 +88,7 @@ extern void *rcu_cmpxchg_pointer_sym(void **p, void *old, void *_new);
 
 extern void *rcu_xchg_pointer_sym(void **p, void *v);
 #define rcu_xchg_pointer(p, v)						     \
+	__extension__							     \
 	({								     \
 		__typeof__(*(p)) _________pv = (v);		             \
 		__typeof__(*(p)) _________p1 = URCU_FORCE_CAST(__typeof__(*(p)), \

--- a/urcu/arch/ppc.h
+++ b/urcu/arch/ppc.h
@@ -58,6 +58,7 @@ extern "C" {
 #define cmm_smp_wmb()    __asm__ __volatile__ (LWSYNC_OPCODE:::"memory")
 
 #define mftbl()						\
+	__extension__					\
 	({ 						\
 		unsigned long rval;			\
 		__asm__ __volatile__ ("mftbl %0" : "=r" (rval));	\
@@ -65,6 +66,7 @@ extern "C" {
 	})
 
 #define mftbu()						\
+	__extension__					\
 	({						\
 		unsigned long rval;			\
 		__asm__ __volatile__ ("mftbu %0" : "=r" (rval));	\
@@ -72,6 +74,7 @@ extern "C" {
 	})
 
 #define mftb()						\
+	__extension__					\
 	({						\
 		unsigned long long rval;		\
 		__asm__ __volatile__ ("mftb %0" : "=r" (rval));		\

--- a/urcu/compiler.h
+++ b/urcu/compiler.h
@@ -64,6 +64,7 @@
  * @member: name of the field within the object.
  */
 #define caa_container_of(ptr, type, member)				\
+	__extension__							\
 	({								\
 		const __typeof__(((type *) NULL)->member) * __ptr = (ptr); \
 		(type *)((char *)__ptr - offsetof(type, member));	\

--- a/urcu/static/urcu-pointer.h
+++ b/urcu/static/urcu-pointer.h
@@ -64,7 +64,9 @@ extern "C" {
  * meets the 10-line criterion in LGPL, allowing this function to be
  * expanded directly in non-LGPL code.
  */
-#define _rcu_dereference(p)     ({					\
+#define _rcu_dereference(p)						\
+				__extension__				\
+				({					\
 				__typeof__(p) _________p1 = CMM_LOAD_SHARED(p); \
 				cmm_smp_read_barrier_depends();		\
 				(_________p1);				\
@@ -82,6 +84,7 @@ extern "C" {
  * expanded directly in non-LGPL code.
  */
 #define _rcu_cmpxchg_pointer(p, old, _new)				\
+	__extension__							\
 	({								\
 		__typeof__(*p) _________pold = (old);			\
 		__typeof__(*p) _________pnew = (_new);			\
@@ -101,6 +104,7 @@ extern "C" {
  * expanded directly in non-LGPL code.
  */
 #define _rcu_xchg_pointer(p, v)				\
+	__extension__					\
 	({						\
 		__typeof__(*p) _________pv = (v);	\
 		if (!__builtin_constant_p(v) ||		\

--- a/urcu/system.h
+++ b/urcu/system.h
@@ -32,6 +32,7 @@
  * Load a data from shared memory, doing a cache flush if required.
  */
 #define CMM_LOAD_SHARED(p)			\
+	__extension__			\
 	({				\
 		cmm_smp_rmc();		\
 		_CMM_LOAD_SHARED(p);	\
@@ -41,13 +42,14 @@
  * Identify a shared store. A cmm_smp_wmc() or cmm_smp_mc() should
  * follow the store.
  */
-#define _CMM_STORE_SHARED(x, v)	({ CMM_ACCESS_ONCE(x) = (v); })
+#define _CMM_STORE_SHARED(x, v)	__extension__ ({ CMM_ACCESS_ONCE(x) = (v); })
 
 /*
  * Store v into x, where x is located in shared memory. Performs the
  * required cache flush after writing. Returns v.
  */
 #define CMM_STORE_SHARED(x, v)						\
+	__extension__							\
 	({								\
 		__typeof__(x) _v = _CMM_STORE_SHARED(x, v);		\
 		cmm_smp_wmc();						\


### PR DESCRIPTION
Dear maintainer(s),

I'm using userspace-rcu in a project, and it's brilliant! But when I try to build my project with -pedantic (GCC 4.7), the build fails due to some macros included from urcu with the error: "ISO C forbids braced-groups within expressions".

As far as I understand, this is due to the fact that braced-groups within expressions are GCC/Clang extensions and not valid ISO C. This pull requests proposes to mark all such uses in macros with __extension__ so that projects including those macros can build with -pedantic -Werror. There is no functional change, and the branch builds and the basic tests (make check) pass on Debian Wheezy and Debian Jessie.

Hope this can be useful!

Kind regards,
Luca Boccassi