### PR TITLE
Cleanup: calloc: swap arguments according to prototype semantic.

### DIFF
--- a/doc/examples/urcu-flavors/bp.c
+++ b/doc/examples/urcu-flavors/bp.c
@@ -46,7 +46,7 @@ int add_node(uint64_t v)
 {
 	struct mynode *node;
 
-	node = calloc(sizeof(*node), 1);
+	node = calloc(1, sizeof(*node));
 	if (!node)
 		return -1;
 	node->value = v;

--- a/doc/examples/urcu-flavors/mb.c
+++ b/doc/examples/urcu-flavors/mb.c
@@ -47,7 +47,7 @@ int add_node(uint64_t v)
 {
 	struct mynode *node;
 
-	node = calloc(sizeof(*node), 1);
+	node = calloc(1, sizeof(*node));
 	if (!node)
 		return -1;
 	node->value = v;

--- a/doc/examples/urcu-flavors/membarrier.c
+++ b/doc/examples/urcu-flavors/membarrier.c
@@ -47,7 +47,7 @@ int add_node(uint64_t v)
 {
 	struct mynode *node;
 
-	node = calloc(sizeof(*node), 1);
+	node = calloc(1, sizeof(*node));
 	if (!node)
 		return -1;
 	node->value = v;

--- a/doc/examples/urcu-flavors/qsbr.c
+++ b/doc/examples/urcu-flavors/qsbr.c
@@ -46,7 +46,7 @@ int add_node(uint64_t v)
 {
 	struct mynode *node;
 
-	node = calloc(sizeof(*node), 1);
+	node = calloc(1, sizeof(*node));
 	if (!node)
 		return -1;
 	node->value = v;

--- a/doc/examples/urcu-flavors/signal.c
+++ b/doc/examples/urcu-flavors/signal.c
@@ -46,7 +46,7 @@ int add_node(uint64_t v)
 {
 	struct mynode *node;
 
-	node = calloc(sizeof(*node), 1);
+	node = calloc(1, sizeof(*node));
 	if (!node)
 		return -1;
 	node->value = v;

--- a/src/urcu-call-rcu-impl.h
+++ b/src/urcu-call-rcu-impl.h
@@ -893,7 +893,7 @@ void rcu_barrier(void)
 		goto online;
 	}
 
-	completion = calloc(sizeof(*completion), 1);
+	completion = calloc(1, sizeof(*completion));
 	if (!completion)
 		urcu_die(errno);
 
@@ -908,7 +908,7 @@ void rcu_barrier(void)
 	cds_list_for_each_entry(crdp, &call_rcu_data_list, list) {
 		struct call_rcu_completion_work *work;
 
-		work = calloc(sizeof(*work), 1);
+		work = calloc(1, sizeof(*work));
 		if (!work)
 			urcu_die(errno);
 		work->completion = completion;

--- a/src/workqueue.c
+++ b/src/workqueue.c
@@ -412,7 +412,7 @@ void urcu_workqueue_queue_completion(struct urcu_workqueue *workqueue,
 {
 	struct urcu_workqueue_completion_work *work;
 
-	work = calloc(sizeof(*work), 1);
+	work = calloc(1, sizeof(*work));
 	if (!work)
 		urcu_die(errno);
 	work->completion = completion;


### PR DESCRIPTION
Greetings~
As we all know that the givenc alloc() args' definition should be like the version below:

void* calloc（unsigned int num，unsigned int size）;

Though it is obvious that the order of the args does not really matters now in calloc() because size and nums are treated as same.
But for better understanding and avoiding the effect caused by possible changes in calloc() in the future, why not make it better?
sincerely,
ruihongw