### PR TITLE
Fix: use underscored attributes names in external headers

### DIFF
--- a/include/urcu/compiler.h
+++ b/include/urcu/compiler.h
@@ -104,10 +104,10 @@
 	&& ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 5)	\
 		|| __GNUC__ >= 5)
 #define CDS_DEPRECATED(msg)	\
-	__attribute__((deprecated(msg)))
+	__attribute__((__deprecated__(msg)))
 #else
 #define CDS_DEPRECATED(msg)	\
-	__attribute__((deprecated))
+	__attribute__((__deprecated__))
 #endif
 
 #define CAA_ARRAY_SIZE(x)	(sizeof(x) / sizeof((x)[0]))

--- a/include/urcu/futex.h
+++ b/include/urcu/futex.h
@@ -122,8 +122,8 @@ static inline int futex_async(int32_t *uaddr, int op, int32_t val,
 
 static inline int futex_async(int32_t *uaddr, int op, int32_t val,
 		const struct timespec *timeout,
-		int32_t *uaddr2 __attribute__((unused)),
-		int32_t val3 __attribute__((unused)))
+		int32_t *uaddr2 __attribute__((__unused__)),
+		int32_t val3 __attribute__((__unused__)))
 {
 	int umtx_op;
 	void *umtx_uaddr = NULL, *umtx_uaddr2 = NULL;

--- a/include/urcu/rculfhash.h
+++ b/include/urcu/rculfhash.h
@@ -63,7 +63,7 @@ struct cds_lfht;
 struct cds_lfht_node {
 	struct cds_lfht_node *next;	/* ptr | REMOVAL_OWNER_FLAG | BUCKET_FLAG | REMOVED_FLAG */
 	unsigned long reverse_hash;
-} __attribute__((aligned(8)));
+} __attribute__((__aligned__(8)));
 
 /* cds_lfht_iter: Used to track state while traversing a hash chain. */
 struct cds_lfht_iter {
@@ -105,7 +105,7 @@ typedef int (*cds_lfht_match_fct)(struct cds_lfht_node *node, const void *key);
  * (detection of memory corruption).
  */
 static inline
-void cds_lfht_node_init(struct cds_lfht_node *node __attribute__((unused)))
+void cds_lfht_node_init(struct cds_lfht_node *node __attribute__((__unused__)))
 {
 }
 

--- a/include/urcu/ref.h
+++ b/include/urcu/ref.h
@@ -34,7 +34,7 @@ static inline void urcu_ref_init(struct urcu_ref *ref)
 	urcu_ref_set(ref, 1);
 }
 
-static inline bool  __attribute__((warn_unused_result))
+static inline bool  __attribute__((__warn_unused_result__))
 		urcu_ref_get_safe(struct urcu_ref *ref)
 {
 	long old, _new, res;

--- a/include/urcu/static/lfstack.h
+++ b/include/urcu/static/lfstack.h
@@ -61,7 +61,7 @@ extern "C" {
  * cds_lfs_node_init: initialize lock-free stack node.
  */
 static inline
-void _cds_lfs_node_init(struct cds_lfs_node *node __attribute__((unused)))
+void _cds_lfs_node_init(struct cds_lfs_node *node __attribute__((__unused__)))
 {
 }
 

--- a/include/urcu/static/pointer.h
+++ b/include/urcu/static/pointer.h
@@ -99,7 +99,7 @@ extern "C" {
 #ifdef __URCU_DEREFERENCE_USE_ATOMIC_CONSUME
 # define _rcu_dereference(p) __extension__ ({						\
 				__typeof__(__extension__ ({				\
-					__typeof__(p) __attribute__((unused)) _________p0 = { 0 }; \
+					__typeof__(p) __attribute__((__unused__)) _________p0 = { 0 }; \
 					_________p0;					\
 				})) _________p1;					\
 				__atomic_load(&(p), &_________p1, __ATOMIC_CONSUME);	\

--- a/include/urcu/static/rculfstack.h
+++ b/include/urcu/static/rculfstack.h
@@ -34,7 +34,7 @@ extern "C" {
 #endif
 
 static inline
-void _cds_lfs_node_init_rcu(struct cds_lfs_node_rcu *node __attribute__((unused)))
+void _cds_lfs_node_init_rcu(struct cds_lfs_node_rcu *node __attribute__((__unused__)))
 {
 }
 

--- a/include/urcu/static/urcu-bp.h
+++ b/include/urcu/static/urcu-bp.h
@@ -91,7 +91,7 @@ struct urcu_bp_reader {
 	/* Data used by both reader and urcu_bp_synchronize_rcu() */
 	unsigned long ctr;
 	/* Data used for registry */
-	struct cds_list_head node __attribute__((aligned(CAA_CACHE_LINE_SIZE)));
+	struct cds_list_head node __attribute__((__aligned__(CAA_CACHE_LINE_SIZE)));
 	pthread_t tid;
 	int alloc;	/* registry entry allocated */
 };

--- a/include/urcu/static/urcu-common.h
+++ b/include/urcu/static/urcu-common.h
@@ -74,14 +74,14 @@ struct urcu_gp {
 	unsigned long ctr;
 
 	int32_t futex;
-} __attribute__((aligned(CAA_CACHE_LINE_SIZE)));
+} __attribute__((__aligned__(CAA_CACHE_LINE_SIZE)));
 
 struct urcu_reader {
 	/* Data used by both reader and synchronize_rcu() */
 	unsigned long ctr;
 	char need_mb;
 	/* Data used for registry */
-	struct cds_list_head node __attribute__((aligned(CAA_CACHE_LINE_SIZE)));
+	struct cds_list_head node __attribute__((__aligned__(CAA_CACHE_LINE_SIZE)));
 	pthread_t tid;
 	/* Reader registered flag, for internal checks. */
 	unsigned int registered:1;

--- a/include/urcu/static/urcu-qsbr.h
+++ b/include/urcu/static/urcu-qsbr.h
@@ -66,7 +66,7 @@ struct urcu_qsbr_reader {
 	/* Data used by both reader and synchronize_rcu() */
 	unsigned long ctr;
 	/* Data used for registry */
-	struct cds_list_head node __attribute__((aligned(CAA_CACHE_LINE_SIZE)));
+	struct cds_list_head node __attribute__((__aligned__(CAA_CACHE_LINE_SIZE)));
 	int waiting;
 	pthread_t tid;
 	/* Reader registered flag, for internal checks. */

--- a/include/urcu/static/wfcqueue.h
+++ b/include/urcu/static/wfcqueue.h
@@ -112,7 +112,7 @@ static inline void _cds_wfcq_init(struct cds_wfcq_head *head,
  * cds_wfcq_init().
  */
 static inline void _cds_wfcq_destroy(struct cds_wfcq_head *head,
-		struct cds_wfcq_tail *tail __attribute__((unused)))
+		struct cds_wfcq_tail *tail __attribute__((__unused__)))
 {
 	int ret = pthread_mutex_destroy(&head->lock);
 	urcu_posix_assert(!ret);
@@ -158,7 +158,7 @@ static inline bool _cds_wfcq_empty(cds_wfcq_head_ptr_t u_head,
 }
 
 static inline void _cds_wfcq_dequeue_lock(struct cds_wfcq_head *head,
-		struct cds_wfcq_tail *tail __attribute__((unused)))
+		struct cds_wfcq_tail *tail __attribute__((__unused__)))
 {
 	int ret;
 
@@ -167,7 +167,7 @@ static inline void _cds_wfcq_dequeue_lock(struct cds_wfcq_head *head,
 }
 
 static inline void _cds_wfcq_dequeue_unlock(struct cds_wfcq_head *head,
-		struct cds_wfcq_tail *tail __attribute__((unused)))
+		struct cds_wfcq_tail *tail __attribute__((__unused__)))
 {
 	int ret;
 
@@ -331,7 +331,7 @@ ___cds_wfcq_first_nonblocking(cds_wfcq_head_ptr_t head,
 }
 
 static inline struct cds_wfcq_node *
-___cds_wfcq_next(cds_wfcq_head_ptr_t head __attribute__((unused)),
+___cds_wfcq_next(cds_wfcq_head_ptr_t head __attribute__((__unused__)),
 		struct cds_wfcq_tail *tail,
 		struct cds_wfcq_node *node,
 		int blocking)

--- a/include/urcu/uatomic/generic.h
+++ b/include/urcu/uatomic/generic.h
@@ -38,7 +38,7 @@ extern "C" {
 #endif
 
 #if !defined __OPTIMIZE__  || defined UATOMIC_NO_LINK_ERROR
-static inline __attribute__((always_inline, noreturn))
+static inline __attribute__((__always_inline__, __noreturn__))
 void _uatomic_link_error(void)
 {
 #ifdef ILLEGAL_INSTR
@@ -59,7 +59,7 @@ extern void _uatomic_link_error(void);
 /* cmpxchg */
 
 #ifndef uatomic_cmpxchg
-static inline __attribute__((always_inline))
+static inline __attribute__((__always_inline__))
 unsigned long _uatomic_cmpxchg(void *addr, unsigned long old,
 			      unsigned long _new, int len)
 {
@@ -98,7 +98,7 @@ unsigned long _uatomic_cmpxchg(void *addr, unsigned long old,
 /* uatomic_and */
 
 #ifndef uatomic_and
-static inline __attribute__((always_inline))
+static inline __attribute__((__always_inline__))
 void _uatomic_and(void *addr, unsigned long val,
 		  int len)
 {
@@ -137,7 +137,7 @@ void _uatomic_and(void *addr, unsigned long val,
 /* uatomic_or */
 
 #ifndef uatomic_or
-static inline __attribute__((always_inline))
+static inline __attribute__((__always_inline__))
 void _uatomic_or(void *addr, unsigned long val,
 		 int len)
 {
@@ -178,7 +178,7 @@ void _uatomic_or(void *addr, unsigned long val,
 /* uatomic_add_return */
 
 #ifndef uatomic_add_return
-static inline __attribute__((always_inline))
+static inline __attribute__((__always_inline__))
 unsigned long _uatomic_add_return(void *addr, unsigned long val,
 				 int len)
 {
@@ -212,7 +212,7 @@ unsigned long _uatomic_add_return(void *addr, unsigned long val,
 #ifndef uatomic_xchg
 /* xchg */
 
-static inline __attribute__((always_inline))
+static inline __attribute__((__always_inline__))
 unsigned long _uatomic_exchange(void *addr, unsigned long val, int len)
 {
 	switch (len) {
@@ -282,7 +282,7 @@ unsigned long _uatomic_exchange(void *addr, unsigned long val, int len)
 #ifndef uatomic_and
 /* uatomic_and */
 
-static inline __attribute__((always_inline))
+static inline __attribute__((__always_inline__))
 void _uatomic_and(void *addr, unsigned long val, int len)
 {
 	switch (len) {
@@ -354,7 +354,7 @@ void _uatomic_and(void *addr, unsigned long val, int len)
 #ifndef uatomic_or
 /* uatomic_or */
 
-static inline __attribute__((always_inline))
+static inline __attribute__((__always_inline__))
 void _uatomic_or(void *addr, unsigned long val, int len)
 {
 	switch (len) {
@@ -428,7 +428,7 @@ void _uatomic_or(void *addr, unsigned long val, int len)
 #ifndef uatomic_add_return
 /* uatomic_add_return */
 
-static inline __attribute__((always_inline))
+static inline __attribute__((__always_inline__))
 unsigned long _uatomic_add_return(void *addr, unsigned long val, int len)
 {
 	switch (len) {
@@ -504,7 +504,7 @@ unsigned long _uatomic_add_return(void *addr, unsigned long val, int len)
 #ifndef uatomic_xchg
 /* xchg */
 
-static inline __attribute__((always_inline))
+static inline __attribute__((__always_inline__))
 unsigned long _uatomic_exchange(void *addr, unsigned long val, int len)
 {
 	switch (len) {

--- a/include/urcu/uatomic/ppc.h
+++ b/include/urcu/uatomic/ppc.h
@@ -54,7 +54,7 @@ extern "C" {
 
 /* xchg */
 
-static inline __attribute__((always_inline))
+static inline __attribute__((__always_inline__))
 unsigned long _uatomic_exchange(void *addr, unsigned long val, int len)
 {
 	switch (len) {
@@ -107,7 +107,7 @@ unsigned long _uatomic_exchange(void *addr, unsigned long val, int len)
 						sizeof(*(addr))))
 /* cmpxchg */
 
-static inline __attribute__((always_inline))
+static inline __attribute__((__always_inline__))
 unsigned long _uatomic_cmpxchg(void *addr, unsigned long old,
 			      unsigned long _new, int len)
 {
@@ -172,7 +172,7 @@ unsigned long _uatomic_cmpxchg(void *addr, unsigned long old,
 
 /* uatomic_add_return */
 
-static inline __attribute__((always_inline))
+static inline __attribute__((__always_inline__))
 unsigned long _uatomic_add_return(void *addr, unsigned long val,
 				 int len)
 {

--- a/include/urcu/uatomic/s390.h
+++ b/include/urcu/uatomic/s390.h
@@ -77,7 +77,7 @@ typedef struct { char v[8]; } __hp_8;
 
 /* xchg */
 
-static inline __attribute__((always_inline))
+static inline __attribute__((__always_inline__))
 unsigned long _uatomic_exchange(volatile void *addr, unsigned long val, int len)
 {
 	switch (len) {
@@ -121,7 +121,7 @@ unsigned long _uatomic_exchange(volatile void *addr, unsigned long val, int len)
 
 /* cmpxchg */
 
-static inline __attribute__((always_inline))
+static inline __attribute__((__always_inline__))
 unsigned long _uatomic_cmpxchg(void *addr, unsigned long old,
 			       unsigned long _new, int len)
 {

--- a/include/urcu/uatomic/sparc64.h
+++ b/include/urcu/uatomic/sparc64.h
@@ -29,7 +29,7 @@ extern "C" {
 
 /* cmpxchg */
 
-static inline __attribute__((always_inline))
+static inline __attribute__((__always_inline__))
 unsigned long _uatomic_cmpxchg(void *addr, unsigned long old,
 			      unsigned long _new, int len)
 {

--- a/include/urcu/uatomic/x86.h
+++ b/include/urcu/uatomic/x86.h
@@ -56,7 +56,7 @@ typedef struct { char v[8]; } __hp_8;
 
 /* cmpxchg */
 
-static inline __attribute__((always_inline))
+static inline __attribute__((__always_inline__))
 unsigned long __uatomic_cmpxchg(void *addr, unsigned long old,
 			      unsigned long _new, int len)
 {
@@ -124,7 +124,7 @@ unsigned long __uatomic_cmpxchg(void *addr, unsigned long old,
 
 /* xchg */
 
-static inline __attribute__((always_inline))
+static inline __attribute__((__always_inline__))
 unsigned long __uatomic_exchange(void *addr, unsigned long val, int len)
 {
 	/* Note: the "xchg" instruction does not need a "lock" prefix. */
@@ -187,7 +187,7 @@ unsigned long __uatomic_exchange(void *addr, unsigned long val, int len)
 
 /* uatomic_add_return */
 
-static inline __attribute__((always_inline))
+static inline __attribute__((__always_inline__))
 unsigned long __uatomic_add_return(void *addr, unsigned long val,
 				 int len)
 {
@@ -254,7 +254,7 @@ unsigned long __uatomic_add_return(void *addr, unsigned long val,
 
 /* uatomic_and */
 
-static inline __attribute__((always_inline))
+static inline __attribute__((__always_inline__))
 void __uatomic_and(void *addr, unsigned long val, int len)
 {
 	switch (len) {
@@ -310,7 +310,7 @@ void __uatomic_and(void *addr, unsigned long val, int len)
 
 /* uatomic_or */
 
-static inline __attribute__((always_inline))
+static inline __attribute__((__always_inline__))
 void __uatomic_or(void *addr, unsigned long val, int len)
 {
 	switch (len) {
@@ -366,7 +366,7 @@ void __uatomic_or(void *addr, unsigned long val, int len)
 
 /* uatomic_add */
 
-static inline __attribute__((always_inline))
+static inline __attribute__((__always_inline__))
 void __uatomic_add(void *addr, unsigned long val, int len)
 {
 	switch (len) {
@@ -423,7 +423,7 @@ void __uatomic_add(void *addr, unsigned long val, int len)
 
 /* uatomic_inc */
 
-static inline __attribute__((always_inline))
+static inline __attribute__((__always_inline__))
 void __uatomic_inc(void *addr, int len)
 {
 	switch (len) {
@@ -476,7 +476,7 @@ void __uatomic_inc(void *addr, int len)
 
 /* uatomic_dec */
 
-static inline __attribute__((always_inline))
+static inline __attribute__((__always_inline__))
 void __uatomic_dec(void *addr, int len)
 {
 	switch (len) {


### PR DESCRIPTION
Each attribute name can be used with 2 underscores before and after it. It can be useful when another library defines a macro with the name of an attribute.

For example, there is [vpp library][1] that defines `always_inline` keyword as corresponding attribute declaration. It leads to compilation error when vpp's headers are included before urcu's ones.

According to [GCC documentation][2], section 4.23, this feature is available since, at least, GCC-2.95.3 release.

[1]: https://github.com/FDio/vpp/blob/master/src/vppinfra/clib.h#L144
[2]: https://gcc.gnu.org/onlinedocs/gcc-2.95.3/gcc_4.html#SEC84