### PR TITLE
Adjust shell scripts to allow Bash in other locations

### DIFF
--- a/tests/benchmark/hashtable_1_seconds.tap
+++ b/tests/benchmark/hashtable_1_seconds.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/benchmark/hashtable_30_seconds.tap
+++ b/tests/benchmark/hashtable_30_seconds.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/benchmark/hashtable_3_seconds.tap
+++ b/tests/benchmark/hashtable_3_seconds.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/benchmark/run-urcu-tests.sh
+++ b/tests/benchmark/run-urcu-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/benchmark/runhash.sh
+++ b/tests/benchmark/runhash.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/benchmark/runtests-batch.sh
+++ b/tests/benchmark/runtests-batch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/benchmark/runtests.sh
+++ b/tests/benchmark/runtests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/benchmark/urcu_1_seconds.tap
+++ b/tests/benchmark/urcu_1_seconds.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/benchmark/urcu_30_seconds.tap
+++ b/tests/benchmark/urcu_30_seconds.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/benchmark/urcu_3_seconds.tap
+++ b/tests/benchmark/urcu_3_seconds.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_bp_perf_global.tap
+++ b/tests/regression/test_rcutorture_urcu_bp_perf_global.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_bp_perf_global_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_bp_perf_global_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_bp_perf_percpu.tap
+++ b/tests/regression/test_rcutorture_urcu_bp_perf_percpu.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_bp_perf_percpu_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_bp_perf_percpu_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_bp_perf_perthread.tap
+++ b/tests/regression/test_rcutorture_urcu_bp_perf_perthread.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_bp_perf_perthread_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_bp_perf_perthread_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_bp_rperf_global.tap
+++ b/tests/regression/test_rcutorture_urcu_bp_rperf_global.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_bp_rperf_global_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_bp_rperf_global_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_bp_rperf_percpu.tap
+++ b/tests/regression/test_rcutorture_urcu_bp_rperf_percpu.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_bp_rperf_percpu_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_bp_rperf_percpu_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_bp_rperf_perthread.tap
+++ b/tests/regression/test_rcutorture_urcu_bp_rperf_perthread.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_bp_rperf_perthread_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_bp_rperf_perthread_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_bp_stress_global.tap
+++ b/tests/regression/test_rcutorture_urcu_bp_stress_global.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_bp_stress_global_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_bp_stress_global_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_bp_stress_percpu.tap
+++ b/tests/regression/test_rcutorture_urcu_bp_stress_percpu.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_bp_stress_percpu_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_bp_stress_percpu_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_bp_stress_perthread.tap
+++ b/tests/regression/test_rcutorture_urcu_bp_stress_perthread.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_bp_stress_perthread_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_bp_stress_perthread_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_bp_uperf_global.tap
+++ b/tests/regression/test_rcutorture_urcu_bp_uperf_global.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_bp_uperf_global_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_bp_uperf_global_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_bp_uperf_percpu.tap
+++ b/tests/regression/test_rcutorture_urcu_bp_uperf_percpu.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_bp_uperf_percpu_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_bp_uperf_percpu_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_bp_uperf_perthread.tap
+++ b/tests/regression/test_rcutorture_urcu_bp_uperf_perthread.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_bp_uperf_perthread_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_bp_uperf_perthread_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_mb_perf_global.tap
+++ b/tests/regression/test_rcutorture_urcu_mb_perf_global.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_mb_perf_global_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_mb_perf_global_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_mb_perf_percpu.tap
+++ b/tests/regression/test_rcutorture_urcu_mb_perf_percpu.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_mb_perf_percpu_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_mb_perf_percpu_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_mb_perf_perthread.tap
+++ b/tests/regression/test_rcutorture_urcu_mb_perf_perthread.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_mb_perf_perthread_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_mb_perf_perthread_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_mb_rperf_global.tap
+++ b/tests/regression/test_rcutorture_urcu_mb_rperf_global.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_mb_rperf_global_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_mb_rperf_global_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_mb_rperf_percpu.tap
+++ b/tests/regression/test_rcutorture_urcu_mb_rperf_percpu.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_mb_rperf_percpu_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_mb_rperf_percpu_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_mb_rperf_perthread.tap
+++ b/tests/regression/test_rcutorture_urcu_mb_rperf_perthread.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_mb_rperf_perthread_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_mb_rperf_perthread_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_mb_stress_global.tap
+++ b/tests/regression/test_rcutorture_urcu_mb_stress_global.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_mb_stress_global_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_mb_stress_global_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_mb_stress_percpu.tap
+++ b/tests/regression/test_rcutorture_urcu_mb_stress_percpu.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_mb_stress_percpu_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_mb_stress_percpu_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_mb_stress_perthread.tap
+++ b/tests/regression/test_rcutorture_urcu_mb_stress_perthread.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_mb_stress_perthread_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_mb_stress_perthread_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_mb_uperf_global.tap
+++ b/tests/regression/test_rcutorture_urcu_mb_uperf_global.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_mb_uperf_global_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_mb_uperf_global_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_mb_uperf_percpu.tap
+++ b/tests/regression/test_rcutorture_urcu_mb_uperf_percpu.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_mb_uperf_percpu_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_mb_uperf_percpu_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_mb_uperf_perthread.tap
+++ b/tests/regression/test_rcutorture_urcu_mb_uperf_perthread.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_mb_uperf_perthread_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_mb_uperf_perthread_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_membarrier_perf_global.tap
+++ b/tests/regression/test_rcutorture_urcu_membarrier_perf_global.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_membarrier_perf_global_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_membarrier_perf_global_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_membarrier_perf_percpu.tap
+++ b/tests/regression/test_rcutorture_urcu_membarrier_perf_percpu.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_membarrier_perf_percpu_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_membarrier_perf_percpu_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_membarrier_perf_perthread.tap
+++ b/tests/regression/test_rcutorture_urcu_membarrier_perf_perthread.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_membarrier_perf_perthread_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_membarrier_perf_perthread_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_membarrier_rperf_global.tap
+++ b/tests/regression/test_rcutorture_urcu_membarrier_rperf_global.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_membarrier_rperf_global_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_membarrier_rperf_global_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_membarrier_rperf_percpu.tap
+++ b/tests/regression/test_rcutorture_urcu_membarrier_rperf_percpu.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_membarrier_rperf_percpu_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_membarrier_rperf_percpu_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_membarrier_rperf_perthread.tap
+++ b/tests/regression/test_rcutorture_urcu_membarrier_rperf_perthread.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_membarrier_rperf_perthread_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_membarrier_rperf_perthread_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_membarrier_stress_global.tap
+++ b/tests/regression/test_rcutorture_urcu_membarrier_stress_global.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_membarrier_stress_global_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_membarrier_stress_global_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_membarrier_stress_percpu.tap
+++ b/tests/regression/test_rcutorture_urcu_membarrier_stress_percpu.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_membarrier_stress_percpu_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_membarrier_stress_percpu_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_membarrier_stress_perthread.tap
+++ b/tests/regression/test_rcutorture_urcu_membarrier_stress_perthread.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_membarrier_stress_perthread_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_membarrier_stress_perthread_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_membarrier_uperf_global.tap
+++ b/tests/regression/test_rcutorture_urcu_membarrier_uperf_global.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_membarrier_uperf_global_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_membarrier_uperf_global_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_membarrier_uperf_percpu.tap
+++ b/tests/regression/test_rcutorture_urcu_membarrier_uperf_percpu.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_membarrier_uperf_percpu_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_membarrier_uperf_percpu_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_membarrier_uperf_perthread.tap
+++ b/tests/regression/test_rcutorture_urcu_membarrier_uperf_perthread.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_membarrier_uperf_perthread_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_membarrier_uperf_perthread_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_qsbr_perf_global.tap
+++ b/tests/regression/test_rcutorture_urcu_qsbr_perf_global.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_qsbr_perf_global_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_qsbr_perf_global_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_qsbr_perf_percpu.tap
+++ b/tests/regression/test_rcutorture_urcu_qsbr_perf_percpu.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_qsbr_perf_percpu_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_qsbr_perf_percpu_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_qsbr_perf_perthread.tap
+++ b/tests/regression/test_rcutorture_urcu_qsbr_perf_perthread.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_qsbr_perf_perthread_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_qsbr_perf_perthread_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_qsbr_rperf_global.tap
+++ b/tests/regression/test_rcutorture_urcu_qsbr_rperf_global.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_qsbr_rperf_global_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_qsbr_rperf_global_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_qsbr_rperf_percpu.tap
+++ b/tests/regression/test_rcutorture_urcu_qsbr_rperf_percpu.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_qsbr_rperf_percpu_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_qsbr_rperf_percpu_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_qsbr_rperf_perthread.tap
+++ b/tests/regression/test_rcutorture_urcu_qsbr_rperf_perthread.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_qsbr_rperf_perthread_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_qsbr_rperf_perthread_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_qsbr_stress_global.tap
+++ b/tests/regression/test_rcutorture_urcu_qsbr_stress_global.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_qsbr_stress_global_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_qsbr_stress_global_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_qsbr_stress_percpu.tap
+++ b/tests/regression/test_rcutorture_urcu_qsbr_stress_percpu.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_qsbr_stress_percpu_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_qsbr_stress_percpu_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_qsbr_stress_perthread.tap
+++ b/tests/regression/test_rcutorture_urcu_qsbr_stress_perthread.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_qsbr_stress_perthread_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_qsbr_stress_perthread_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_qsbr_uperf_global.tap
+++ b/tests/regression/test_rcutorture_urcu_qsbr_uperf_global.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_qsbr_uperf_global_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_qsbr_uperf_global_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_qsbr_uperf_percpu.tap
+++ b/tests/regression/test_rcutorture_urcu_qsbr_uperf_percpu.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_qsbr_uperf_percpu_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_qsbr_uperf_percpu_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_qsbr_uperf_perthread.tap
+++ b/tests/regression/test_rcutorture_urcu_qsbr_uperf_perthread.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_qsbr_uperf_perthread_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_qsbr_uperf_perthread_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_signal_perf_global.tap
+++ b/tests/regression/test_rcutorture_urcu_signal_perf_global.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_signal_perf_global_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_signal_perf_global_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_signal_perf_percpu.tap
+++ b/tests/regression/test_rcutorture_urcu_signal_perf_percpu.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_signal_perf_percpu_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_signal_perf_percpu_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_signal_perf_perthread.tap
+++ b/tests/regression/test_rcutorture_urcu_signal_perf_perthread.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_signal_perf_perthread_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_signal_perf_perthread_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_signal_rperf_global.tap
+++ b/tests/regression/test_rcutorture_urcu_signal_rperf_global.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_signal_rperf_global_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_signal_rperf_global_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_signal_rperf_percpu.tap
+++ b/tests/regression/test_rcutorture_urcu_signal_rperf_percpu.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_signal_rperf_percpu_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_signal_rperf_percpu_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_signal_rperf_perthread.tap
+++ b/tests/regression/test_rcutorture_urcu_signal_rperf_perthread.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_signal_rperf_perthread_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_signal_rperf_perthread_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_signal_stress_global.tap
+++ b/tests/regression/test_rcutorture_urcu_signal_stress_global.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_signal_stress_global_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_signal_stress_global_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_signal_stress_percpu.tap
+++ b/tests/regression/test_rcutorture_urcu_signal_stress_percpu.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_signal_stress_percpu_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_signal_stress_percpu_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_signal_stress_perthread.tap
+++ b/tests/regression/test_rcutorture_urcu_signal_stress_perthread.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_signal_stress_perthread_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_signal_stress_perthread_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_signal_uperf_global.tap
+++ b/tests/regression/test_rcutorture_urcu_signal_uperf_global.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_signal_uperf_global_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_signal_uperf_global_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_signal_uperf_percpu.tap
+++ b/tests/regression/test_rcutorture_urcu_signal_uperf_percpu.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_signal_uperf_percpu_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_signal_uperf_percpu_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_signal_uperf_perthread.tap
+++ b/tests/regression/test_rcutorture_urcu_signal_uperf_perthread.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/regression/test_rcutorture_urcu_signal_uperf_perthread_cxx.tap
+++ b/tests/regression/test_rcutorture_urcu_signal_uperf_perthread_cxx.tap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/unit/test_get_cpu_mask_from_sysfs
+++ b/tests/unit/test_get_cpu_mask_from_sysfs
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 if [ "x${URCU_TESTS_SRCDIR:-}" != "x" ]; then

--- a/tests/unit/test_get_cpu_mask_from_sysfs_cxx
+++ b/tests/unit/test_get_cpu_mask_from_sysfs_cxx
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 if [ "x${URCU_TESTS_SRCDIR:-}" != "x" ]; then

--- a/tests/unit/test_get_max_cpuid_from_sysfs
+++ b/tests/unit/test_get_max_cpuid_from_sysfs
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 if [ "x${URCU_TESTS_SRCDIR:-}" != "x" ]; then

--- a/tests/unit/test_get_max_cpuid_from_sysfs_cxx
+++ b/tests/unit/test_get_max_cpuid_from_sysfs_cxx
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 if [ "x${URCU_TESTS_SRCDIR:-}" != "x" ]; then

--- a/tests/utils/env.sh.in
+++ b/tests/utils/env.sh.in
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #

--- a/tests/utils/tap.sh
+++ b/tests/utils/tap.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2010 Patrick LeBoutillier <patrick.leboutillier@gmail.com>
 #
@@ -65,7 +65,7 @@ OTHER:
   diag MSG
 
 EXAMPLE:
-  #!/bin/bash
+  #!/usr/bin/env bash
 
   . tap-functions
 

--- a/tests/utils/utils.sh
+++ b/tests/utils/utils.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #


### PR DESCRIPTION
Linux-based OS for the most part provide Bash and being located in /bin, but on other OS's the shell would be in another location. Utilize env(1) and allow it to be located elsewhere.