### PR TITLE
Use sysconf _SC_NPROCESSORS_ONLN where available

### DIFF
--- a/src/compat-smp.h
+++ b/src/compat-smp.h
@@ -24,7 +24,11 @@
 #if defined(HAVE_SYSCONF)
 static inline int get_num_possible_cpus_sysconf(void)
 {
+#ifdef _SC_NPROCESSORS_ONLN
+	return sysconf(_SC_NPROCESSORS_ONLN);
+#else
 	return sysconf(_SC_NPROCESSORS_CONF);
+#endif
 }
 #else
 /*
@@ -104,8 +108,8 @@ static inline int get_max_cpuid_from_sysfs(void)
  * "cpu" followed by an integer, keep the highest CPU id encountered during
  * this iteration and add 1 to get a number of CPUs.
  *
- * Then get the value from sysconf(_SC_NPROCESSORS_CONF) as a fallback and
- * return the highest one.
+ * Then get the value from sysconf(_SC_NPROCESSORS_ONLN / _SC_NPROCESSORS_CONF)
+ * as a fallback and return the highest one.
  *
  * On Linux, using the value from sysconf can be unreliable since the way it
  * counts CPUs varies between C libraries and even between versions of the same

--- a/src/urcu-call-rcu-impl.h
+++ b/src/urcu-call-rcu-impl.h
@@ -108,8 +108,8 @@ static struct call_rcu_data *default_call_rcu_data;
 static struct urcu_atfork *registered_rculfhash_atfork;
 
 /*
- * If the sched_getcpu() and sysconf(_SC_NPROCESSORS_CONF) calls are
- * available, then we can have call_rcu threads assigned to individual
+ * If the sched_getcpu() and sysconf(_SC_NPROCESSORS_ONLN / _SC_NPROCESSORS_CONF)
+ * calls are available, then we can have call_rcu threads assigned to individual
  * CPUs rather than only to specific threads.
  */
 


### PR DESCRIPTION
Utilize _SC_NPROCESSORS_ONLN to determine the number of CPUs that are online. The number of CPUs configured vs online might vary depending on the OS. OpenBSD for example defaults to sysctl hw.smt=0. So a 2 core 2 thread CPU would only have 2 CPUs exposed to the OS instead of 4.