### PR TITLE
ppc.h: use mftb on ppc

### DIFF
--- a/include/urcu/arch/ppc.h
+++ b/include/urcu/arch/ppc.h
@@ -51,7 +51,7 @@ extern "C" {
 	__extension__					\
 	({ 						\
 		unsigned long rval;			\
-		__asm__ __volatile__ ("mftbl %0" : "=r" (rval));	\
+		__asm__ __volatile__ ("mftb %0" : "=r" (rval));	\
 		rval;					\
 	})
 


### PR DESCRIPTION
`mftbl` does not work, it should be defined to use `mftb`.