### PR TITLE
ppc.h: use correct cacheline size for macOS

### DIFF
--- a/include/urcu/arch/ppc.h
+++ b/include/urcu/arch/ppc.h
@@ -19,8 +19,12 @@
 extern "C" {
 #endif
 
+#ifdef __APPLE__
+#define CAA_CACHE_LINE_SIZE	128
+#else
 /* Include size of POWER5+ L3 cache lines: 256 bytes */
 #define CAA_CACHE_LINE_SIZE	256
+#endif
 
 #ifdef __NO_LWSYNC__
 #define LWSYNC_OPCODE	"sync\n"


### PR DESCRIPTION
Commit https://github.com/urcu/userspace-rcu/commit/b4e52e3e9e563d38607a8e0ab0aa72e7ab2b47b4 unconditionally switched to 256 for PowerPC, which is wrong, AFAIK.
Fallback to 128 for Apple case at least.