### PR TITLE
rculfhash: Add support for custom memory allocator

### DIFF
--- a/src/rculfhash-internal.h
+++ b/src/rculfhash-internal.h
@@ -59,6 +59,7 @@ struct cds_lfht {
 	/* Initial configuration items */
 	unsigned long max_nr_buckets;
 	const struct cds_lfht_mm_type *mm;	/* memory management plugin */
+	const struct cds_lfht_alloc *alloc; /* memory allocator for mm */
 	const struct rcu_flavor_struct *flavor;	/* RCU flavor */
 
 	long count;			/* global approximate item count */
@@ -139,30 +140,32 @@ extern unsigned int cds_lfht_fls_ulong(unsigned long x);
 extern int cds_lfht_get_count_order_ulong(unsigned long x);
 
 #ifdef POISON_FREE
-#define poison_free(ptr)					\
+#define poison_free(alloc, ptr)					\
 	do {							\
 		if (ptr) {					\
 			memset(ptr, 0x42, sizeof(*(ptr)));	\
-			free(ptr);				\
+			alloc->free(alloc->state, ptr);				\
 		}						\
 	} while (0)
 #else
-#define poison_free(ptr)	free(ptr)
+#define poison_free(alloc, ptr)	alloc->free(alloc->state, ptr)
 #endif
 
 static inline
 struct cds_lfht *__default_alloc_cds_lfht(
 		const struct cds_lfht_mm_type *mm,
+		const struct cds_lfht_alloc *alloc,
 		unsigned long cds_lfht_size,
 		unsigned long min_nr_alloc_buckets,
 		unsigned long max_nr_buckets)
 {
 	struct cds_lfht *ht;
 
-	ht = calloc(1, cds_lfht_size);
+	ht = alloc->calloc(alloc->state, 1, cds_lfht_size);
 	urcu_posix_assert(ht);
 
 	ht->mm = mm;
+	ht->alloc = alloc;
 	ht->bucket_at = mm->bucket_at;
 	ht->min_nr_alloc_buckets = min_nr_alloc_buckets;
 	ht->min_alloc_buckets_order =

--- a/src/rculfhash-mm-chunk.c
+++ b/src/rculfhash-mm-chunk.c
@@ -14,15 +14,15 @@ static
 void cds_lfht_alloc_bucket_table(struct cds_lfht *ht, unsigned long order)
 {
 	if (order == 0) {
-		ht->tbl_chunk[0] = calloc(ht->min_nr_alloc_buckets,
-			sizeof(struct cds_lfht_node));
+		ht->tbl_chunk[0] = ht->alloc->calloc(ht->alloc->state,
+			ht->min_nr_alloc_buckets, sizeof(struct cds_lfht_node));
 		urcu_posix_assert(ht->tbl_chunk[0]);
 	} else if (order > ht->min_alloc_buckets_order) {
 		unsigned long i, len = 1UL << (order - 1 - ht->min_alloc_buckets_order);
 
 		for (i = len; i < 2 * len; i++) {
-			ht->tbl_chunk[i] = calloc(ht->min_nr_alloc_buckets,
-				sizeof(struct cds_lfht_node));
+			ht->tbl_chunk[i] = ht->alloc->calloc(ht->alloc->state,
+				ht->min_nr_alloc_buckets, sizeof(struct cds_lfht_node));
 			urcu_posix_assert(ht->tbl_chunk[i]);
 		}
 	}
@@ -38,12 +38,12 @@ static
 void cds_lfht_free_bucket_table(struct cds_lfht *ht, unsigned long order)
 {
 	if (order == 0)
-		poison_free(ht->tbl_chunk[0]);
+		poison_free(ht->alloc, ht->tbl_chunk[0]);
 	else if (order > ht->min_alloc_buckets_order) {
 		unsigned long i, len = 1UL << (order - 1 - ht->min_alloc_buckets_order);
 
 		for (i = len; i < 2 * len; i++)
-			poison_free(ht->tbl_chunk[i]);
+			poison_free(ht->alloc, ht->tbl_chunk[i]);
 	}
 	/* Nothing to do for 0 < order && order <= ht->min_alloc_buckets_order */
 }
@@ -60,7 +60,7 @@ struct cds_lfht_node *bucket_at(struct cds_lfht *ht, unsigned long index)
 
 static
 struct cds_lfht *alloc_cds_lfht(unsigned long min_nr_alloc_buckets,
-		unsigned long max_nr_buckets)
+		unsigned long max_nr_buckets, const struct cds_lfht_alloc *alloc)
 {
 	unsigned long nr_chunks, cds_lfht_size;
 
@@ -72,7 +72,7 @@ struct cds_lfht *alloc_cds_lfht(unsigned long min_nr_alloc_buckets,
 	cds_lfht_size = max(cds_lfht_size, sizeof(struct cds_lfht));
 
 	return __default_alloc_cds_lfht(
-			&cds_lfht_mm_chunk, cds_lfht_size,
+			&cds_lfht_mm_chunk, alloc, cds_lfht_size,
 			min_nr_alloc_buckets, max_nr_buckets);
 }
 

--- a/src/rculfhash-mm-mmap.c
+++ b/src/rculfhash-mm-mmap.c
@@ -118,8 +118,8 @@ void cds_lfht_alloc_bucket_table(struct cds_lfht *ht, unsigned long order)
 	if (order == 0) {
 		if (ht->min_nr_alloc_buckets == ht->max_nr_buckets) {
 			/* small table */
-			ht->tbl_mmap = calloc(ht->max_nr_buckets,
-					sizeof(*ht->tbl_mmap));
+			ht->tbl_mmap = ht->alloc->calloc(ht->alloc->state,
+					ht->max_nr_buckets, sizeof(*ht->tbl_mmap));
 			urcu_posix_assert(ht->tbl_mmap);
 			return;
 		}
@@ -150,7 +150,7 @@ void cds_lfht_free_bucket_table(struct cds_lfht *ht, unsigned long order)
 	if (order == 0) {
 		if (ht->min_nr_alloc_buckets == ht->max_nr_buckets) {
 			/* small table */
-			poison_free(ht->tbl_mmap);
+			poison_free(ht->alloc, ht->tbl_mmap);
 			return;
 		}
 		/* large table */
@@ -174,7 +174,7 @@ struct cds_lfht_node *bucket_at(struct cds_lfht *ht, unsigned long index)
 
 static
 struct cds_lfht *alloc_cds_lfht(unsigned long min_nr_alloc_buckets,
-		unsigned long max_nr_buckets)
+		unsigned long max_nr_buckets, const struct cds_lfht_alloc *alloc)
 {
 	unsigned long page_bucket_size;
 
@@ -189,7 +189,7 @@ struct cds_lfht *alloc_cds_lfht(unsigned long min_nr_alloc_buckets,
 	}
 
 	return __default_alloc_cds_lfht(
-			&cds_lfht_mm_mmap, sizeof(struct cds_lfht),
+			&cds_lfht_mm_mmap, alloc, sizeof(struct cds_lfht),
 			min_nr_alloc_buckets, max_nr_buckets);
 }
 

--- a/src/rculfhash-mm-order.c
+++ b/src/rculfhash-mm-order.c
@@ -14,12 +14,12 @@ static
 void cds_lfht_alloc_bucket_table(struct cds_lfht *ht, unsigned long order)
 {
 	if (order == 0) {
-		ht->tbl_order[0] = calloc(ht->min_nr_alloc_buckets,
-			sizeof(struct cds_lfht_node));
+		ht->tbl_order[0] = ht->alloc->calloc(ht->alloc->state,
+			ht->min_nr_alloc_buckets, sizeof(struct cds_lfht_node));
 		urcu_posix_assert(ht->tbl_order[0]);
 	} else if (order > ht->min_alloc_buckets_order) {
-		ht->tbl_order[order] = calloc(1UL << (order -1),
-			sizeof(struct cds_lfht_node));
+		ht->tbl_order[order] = ht->alloc->calloc(ht->alloc->state,
+			1UL << (order -1), sizeof(struct cds_lfht_node));
 		urcu_posix_assert(ht->tbl_order[order]);
 	}
 	/* Nothing to do for 0 < order && order <= ht->min_alloc_buckets_order */
@@ -34,9 +34,9 @@ static
 void cds_lfht_free_bucket_table(struct cds_lfht *ht, unsigned long order)
 {
 	if (order == 0)
-		poison_free(ht->tbl_order[0]);
+		poison_free(ht->alloc, ht->tbl_order[0]);
 	else if (order > ht->min_alloc_buckets_order)
-		poison_free(ht->tbl_order[order]);
+		poison_free(ht->alloc, ht->tbl_order[order]);
 	/* Nothing to do for 0 < order && order <= ht->min_alloc_buckets_order */
 }
 
@@ -62,10 +62,10 @@ struct cds_lfht_node *bucket_at(struct cds_lfht *ht, unsigned long index)
 
 static
 struct cds_lfht *alloc_cds_lfht(unsigned long min_nr_alloc_buckets,
-		unsigned long max_nr_buckets)
+		unsigned long max_nr_buckets, const struct cds_lfht_alloc *alloc)
 {
 	return __default_alloc_cds_lfht(
-			&cds_lfht_mm_order, sizeof(struct cds_lfht),
+			&cds_lfht_mm_order, alloc, sizeof(struct cds_lfht),
 			min_nr_alloc_buckets, max_nr_buckets);
 }
 


### PR DESCRIPTION
Hi,

The current implementation of rculfhash relies on `calloc()` to allocate memory for its buckets.
This can in some cases lead to latency spikes when accessing the hash table, which can be avoided by using an optimized custom memory allocator. However, there is currently no way of replacing the default allocator with a custom one. 
 
This PR proposes a change to this behavior, by allowing custom allocators to be used during the table initialization.
The default behavior of the hash table remains unaffected, by using the stdlib `calloc()` and `free()`, if no custom allocator is given.

Thanks,
Xenofon
 