### PR TITLE
Improvements to LFHT

### DIFF
--- a/include/urcu/rculfhash.h
+++ b/include/urcu/rculfhash.h
@@ -128,7 +128,7 @@ enum {
 struct cds_lfht_mm_type {
 	struct cds_lfht *(*alloc_cds_lfht)(unsigned long min_nr_alloc_buckets,
 			unsigned long max_nr_buckets, const struct cds_lfht_alloc *alloc);
-	void (*alloc_bucket_table)(struct cds_lfht *ht, unsigned long order);
+	int (*alloc_bucket_table)(struct cds_lfht *ht, unsigned long order);
 	void (*free_bucket_table)(struct cds_lfht *ht, unsigned long order);
 	struct cds_lfht_node *(*bucket_at)(struct cds_lfht *ht,
 			unsigned long index);

--- a/src/rculfhash-internal.h
+++ b/src/rculfhash-internal.h
@@ -76,7 +76,6 @@ struct cds_lfht {
 	pthread_attr_t resize_attr;
 	unsigned int in_progress_destroy;
 	unsigned long resize_target;
-	int resize_initiated;
 	struct urcu_work destroy_work;
 
 	/*

--- a/src/rculfhash-internal.h
+++ b/src/rculfhash-internal.h
@@ -162,7 +162,8 @@ struct cds_lfht *__default_alloc_cds_lfht(
 	struct cds_lfht *ht;
 
 	ht = alloc->calloc(alloc->state, 1, cds_lfht_size);
-	urcu_posix_assert(ht);
+	if (ht == NULL)
+		return NULL;
 
 	ht->mm = mm;
 	ht->alloc = alloc;

--- a/src/rculfhash-mm-chunk.c
+++ b/src/rculfhash-mm-chunk.c
@@ -23,6 +23,7 @@ int cds_lfht_alloc_bucket_table(struct cds_lfht *ht, unsigned long order)
 		unsigned long i, len = 1UL << (order - 1 - ht->min_alloc_buckets_order);
 
 		for (i = len; i < 2 * len; i++) {
+			urcu_posix_assert(i <  ht->max_nr_buckets / ht->min_nr_alloc_buckets);
 			ht->tbl_chunk[i] = ht->alloc->calloc(ht->alloc->state,
 				ht->min_nr_alloc_buckets, sizeof(struct cds_lfht_node));
 			if (ht->tbl_chunk[i] == NULL) {
@@ -78,7 +79,6 @@ struct cds_lfht *alloc_cds_lfht(unsigned long min_nr_alloc_buckets,
 	nr_chunks = max_nr_buckets / min_nr_alloc_buckets;
 	cds_lfht_size = offsetof(struct cds_lfht, tbl_chunk) +
 			sizeof(struct cds_lfht_node *) * nr_chunks;
-	cds_lfht_size = max(cds_lfht_size, sizeof(struct cds_lfht));
 
 	return __default_alloc_cds_lfht(
 			&cds_lfht_mm_chunk, alloc, cds_lfht_size,

--- a/src/rculfhash-mm-mmap.c
+++ b/src/rculfhash-mm-mmap.c
@@ -187,7 +187,7 @@ static
 struct cds_lfht *alloc_cds_lfht(unsigned long min_nr_alloc_buckets,
 		unsigned long max_nr_buckets, const struct cds_lfht_alloc *alloc)
 {
-	unsigned long page_bucket_size;
+	unsigned long page_bucket_size, cds_lfht_size;
 
 	page_bucket_size = getpagesize() / sizeof(struct cds_lfht_node);
 	if (max_nr_buckets <= page_bucket_size) {
@@ -198,9 +198,11 @@ struct cds_lfht *alloc_cds_lfht(unsigned long min_nr_alloc_buckets,
 		min_nr_alloc_buckets = max(min_nr_alloc_buckets,
 					page_bucket_size);
 	}
+	cds_lfht_size = offsetof(struct cds_lfht, tbl_mmap) +
+			sizeof(struct cds_lfht_node *);
 
 	return __default_alloc_cds_lfht(
-			&cds_lfht_mm_mmap, alloc, sizeof(struct cds_lfht),
+			&cds_lfht_mm_mmap, alloc, cds_lfht_size,
 			min_nr_alloc_buckets, max_nr_buckets);
 }
 

--- a/src/rculfhash-mm-mmap.c
+++ b/src/rculfhash-mm-mmap.c
@@ -46,10 +46,6 @@ void *memory_map(size_t length)
 	void *ret;
 
 	ret = mmap(NULL, length, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-	if (ret == MAP_FAILED) {
-		perror("mmap");
-		abort();
-	}
 	return ret;
 }
 
@@ -65,12 +61,12 @@ void memory_unmap(void *ptr, size_t length)
 #ifdef __CYGWIN__
 /* Set protection to read/write to allocate a memory chunk */
 static
-void memory_populate(void *ptr, size_t length)
+int memory_populate(void *ptr, size_t length)
 {
 	if (mprotect(ptr, length, PROT_READ | PROT_WRITE)) {
-		perror("mprotect");
-		abort();
+		return -1;
 	}
+	return 0;
 }
 
 /* Set protection to none to deallocate a memory chunk */
@@ -86,14 +82,16 @@ void memory_discard(void *ptr, size_t length)
 #else /* __CYGWIN__ */
 
 static
-void memory_populate(void *ptr, size_t length)
+int memory_populate(void *ptr, size_t length)
 {
 	if (mmap(ptr, length, PROT_READ | PROT_WRITE,
 			MAP_FIXED | MAP_PRIVATE | MAP_ANONYMOUS,
 			-1, 0) != ptr) {
-		perror("mmap");
-		abort();
+		/* ENOMEM on freebsd */
+		urcu_posix_assert(errno != EINVAL);
+		return -1;
 	}
+	return 0;
 }
 
 /*
@@ -106,37 +104,50 @@ void memory_discard(void *ptr, size_t length)
 	if (mmap(ptr, length, PROT_NONE,
 			MAP_FIXED | MAP_PRIVATE | MAP_ANONYMOUS,
 			-1, 0) != ptr) {
-		perror("mmap");
+		/* ENOMEM on freebsd */
+		urcu_posix_assert(errno != EINVAL);
+#if 0
+		perror("mmap discard");
 		abort();
+#endif
 	}
 }
 #endif /* __CYGWIN__ */
 
 static
-void cds_lfht_alloc_bucket_table(struct cds_lfht *ht, unsigned long order)
+int cds_lfht_alloc_bucket_table(struct cds_lfht *ht, unsigned long order)
 {
 	if (order == 0) {
 		if (ht->min_nr_alloc_buckets == ht->max_nr_buckets) {
 			/* small table */
 			ht->tbl_mmap = ht->alloc->calloc(ht->alloc->state,
 					ht->max_nr_buckets, sizeof(*ht->tbl_mmap));
-			urcu_posix_assert(ht->tbl_mmap);
-			return;
+			if (ht->tbl_mmap == NULL)
+				return -1;
+			return 0;
 		}
 		/* large table */
 		ht->tbl_mmap = memory_map(ht->max_nr_buckets
 			* sizeof(*ht->tbl_mmap));
-		memory_populate(ht->tbl_mmap,
-			ht->min_nr_alloc_buckets * sizeof(*ht->tbl_mmap));
+		if (ht->tbl_mmap == MAP_FAILED)
+			return -1;
+		if (memory_populate(ht->tbl_mmap, ht->min_nr_alloc_buckets
+					* sizeof(*ht->tbl_mmap))) {
+			memory_unmap(ht->tbl_mmap,
+				ht->max_nr_buckets * sizeof(*ht->tbl_mmap));
+			return -1;
+		}
 	} else if (order > ht->min_alloc_buckets_order) {
 		/* large table */
 		unsigned long len = 1UL << (order - 1);
 
 		urcu_posix_assert(ht->min_nr_alloc_buckets < ht->max_nr_buckets);
-		memory_populate(ht->tbl_mmap + len,
-				len * sizeof(*ht->tbl_mmap));
+		if (memory_populate(ht->tbl_mmap + len,
+				len * sizeof(*ht->tbl_mmap)))
+			return -1;
 	}
 	/* Nothing to do for 0 < order && order <= ht->min_alloc_buckets_order */
+	return 0;
 }
 
 /*

--- a/src/rculfhash-mm-order.c
+++ b/src/rculfhash-mm-order.c
@@ -13,6 +13,8 @@
 static
 int cds_lfht_alloc_bucket_table(struct cds_lfht *ht, unsigned long order)
 {
+	urcu_posix_assert(order <=
+		(unsigned)cds_lfht_get_count_order_ulong(ht->max_nr_buckets));
 	if (order == 0) {
 		ht->tbl_order[0] = ht->alloc->calloc(ht->alloc->state,
 			ht->min_nr_alloc_buckets, sizeof(struct cds_lfht_node));
@@ -68,8 +70,14 @@ static
 struct cds_lfht *alloc_cds_lfht(unsigned long min_nr_alloc_buckets,
 		unsigned long max_nr_buckets, const struct cds_lfht_alloc *alloc)
 {
+	unsigned long max_order, cds_lfht_size;
+
+	max_order = cds_lfht_get_count_order_ulong(max_nr_buckets);
+	cds_lfht_size = offsetof(struct cds_lfht, tbl_order) +
+			sizeof(struct cds_lfht_node *) * (max_order + 1);
+
 	return __default_alloc_cds_lfht(
-			&cds_lfht_mm_order, alloc, sizeof(struct cds_lfht),
+			&cds_lfht_mm_order, alloc, cds_lfht_size,
 			min_nr_alloc_buckets, max_nr_buckets);
 }
 

--- a/src/rculfhash-mm-order.c
+++ b/src/rculfhash-mm-order.c
@@ -11,18 +11,22 @@
 #include "rculfhash-internal.h"
 
 static
-void cds_lfht_alloc_bucket_table(struct cds_lfht *ht, unsigned long order)
+int cds_lfht_alloc_bucket_table(struct cds_lfht *ht, unsigned long order)
 {
 	if (order == 0) {
 		ht->tbl_order[0] = ht->alloc->calloc(ht->alloc->state,
 			ht->min_nr_alloc_buckets, sizeof(struct cds_lfht_node));
-		urcu_posix_assert(ht->tbl_order[0]);
+		if (ht->tbl_order[0] == NULL)
+			return -1;
+
 	} else if (order > ht->min_alloc_buckets_order) {
 		ht->tbl_order[order] = ht->alloc->calloc(ht->alloc->state,
 			1UL << (order -1), sizeof(struct cds_lfht_node));
-		urcu_posix_assert(ht->tbl_order[order]);
+		if (ht->tbl_order[order] == NULL)
+			return -1;
 	}
 	/* Nothing to do for 0 < order && order <= ht->min_alloc_buckets_order */
+	return 0;
 }
 
 /*

--- a/src/urcu-call-rcu-impl.h
+++ b/src/urcu-call-rcu-impl.h
@@ -333,7 +333,7 @@ static void *call_rcu_thread(void *arg)
 		cmm_smp_mb();
 	}
 	for (;;) {
-		struct cds_wfcq_head cbs_tmp_head;
+		struct __cds_wfcq_head cbs_tmp_head;
 		struct cds_wfcq_tail cbs_tmp_tail;
 		struct cds_wfcq_node *cbs, *cbs_tmp_n;
 		enum cds_wfcq_ret splice_ret;
@@ -358,7 +358,7 @@ static void *call_rcu_thread(void *arg)
 			rcu_register_thread();
 		}
 
-		cds_wfcq_init(&cbs_tmp_head, &cbs_tmp_tail);
+		__cds_wfcq_init(&cbs_tmp_head, &cbs_tmp_tail);
 		splice_ret = __cds_wfcq_splice_blocking(&cbs_tmp_head,
 			&cbs_tmp_tail, &crdp->cbs_head, &crdp->cbs_tail);
 		urcu_posix_assert(splice_ret != CDS_WFCQ_RET_WOULDBLOCK);
@@ -377,8 +377,11 @@ static void *call_rcu_thread(void *arg)
 			}
 			uatomic_sub(&crdp->qlen, cbcount);
 		}
+		/*cds_wfcq_destroy(&cbs_tmp_head, &cbs_tmp_tail);*/
+
 		if (uatomic_read(&crdp->flags) & URCU_CALL_RCU_STOP)
 			break;
+
 		rcu_thread_offline();
 		if (!rt) {
 			if (cds_wfcq_empty(&crdp->cbs_head,

--- a/src/workqueue.c
+++ b/src/workqueue.c
@@ -86,7 +86,7 @@ static int set_thread_cpu_affinity(struct urcu_workqueue *workqueue)
 
 	if (workqueue->cpu_affinity < 0)
 		return 0;
-	if (++workqueue->loop_count & SET_AFFINITY_CHECK_PERIOD_MASK)
+	if (workqueue->loop_count++ & SET_AFFINITY_CHECK_PERIOD_MASK)
 		return 0;
 	if (urcu_sched_getcpu() == workqueue->cpu_affinity)
 		return 0;
@@ -163,6 +163,7 @@ static void *workqueue_thread(void *arg)
 	struct urcu_workqueue *workqueue = (struct urcu_workqueue *) arg;
 	int rt = !!(uatomic_read(&workqueue->flags) & URCU_WORKQUEUE_RT);
 
+	/* XXX needed? */
 	if (set_thread_cpu_affinity(workqueue))
 		urcu_die(errno);
 
@@ -275,10 +276,10 @@ struct urcu_workqueue *urcu_workqueue_create(unsigned long flags,
 	int ret;
 	sigset_t newmask, oldmask;
 
-	workqueue = malloc(sizeof(*workqueue));
+	workqueue = calloc(1, sizeof(*workqueue));
 	if (workqueue == NULL)
 		urcu_die(errno);
-	memset(workqueue, '\0', sizeof(*workqueue));
+
 	cds_wfcq_init(&workqueue->cbs_head, &workqueue->cbs_tail);
 	workqueue->qlen = 0;
 	workqueue->futex = 0;

--- a/src/workqueue.c
+++ b/src/workqueue.c
@@ -175,7 +175,7 @@ static void *workqueue_thread(void *arg)
 		cmm_smp_mb();
 	}
 	for (;;) {
-		struct cds_wfcq_head cbs_tmp_head;
+		struct __cds_wfcq_head cbs_tmp_head;
 		struct cds_wfcq_tail cbs_tmp_tail;
 		struct cds_wfcq_node *cbs, *cbs_tmp_n;
 		enum cds_wfcq_ret splice_ret;
@@ -202,7 +202,7 @@ static void *workqueue_thread(void *arg)
 				workqueue->worker_after_resume_fct(workqueue, workqueue->priv);
 		}
 
-		cds_wfcq_init(&cbs_tmp_head, &cbs_tmp_tail);
+		__cds_wfcq_init(&cbs_tmp_head, &cbs_tmp_tail);
 		splice_ret = __cds_wfcq_splice_blocking(&cbs_tmp_head,
 			&cbs_tmp_tail, &workqueue->cbs_head, &workqueue->cbs_tail);
 		urcu_posix_assert(splice_ret != CDS_WFCQ_RET_WOULDBLOCK);
@@ -222,8 +222,11 @@ static void *workqueue_thread(void *arg)
 			}
 			uatomic_sub(&workqueue->qlen, cbcount);
 		}
+		/*cds_wfcq_destroy(&cbs_tmp_head, &cbs_tmp_tail);*/
+
 		if (uatomic_read(&workqueue->flags) & URCU_WORKQUEUE_STOP)
 			break;
+
 		if (workqueue->worker_before_wait_fct)
 			workqueue->worker_before_wait_fct(workqueue, workqueue->priv);
 		if (!rt) {


### PR DESCRIPTION
The earliest commit adds error checking to the memory allocations done by cds_lfht_new, so that NULL is returned instead of triggering an assertion. For compatibility with existing apps I've sprinkled public functions with assert(ht). As for resizes, they are now interrupted when out of memory. This is not perfect--the table may remain too small for too long--but better than dumping core.

Another commit reduces the size of struct cds_lfht. These things matter to me as my application creates tons of hash tables dynamically.

Two more commits pertain to call_rcu and workqueue. One fixes a mutex leak on FreeBSD (I gather the mutex is not needed there at all). Another one is a minor tweak to set cpu affinity as early as possible, not 255 iterations later.